### PR TITLE
Fix spectator bug for non-vr clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ A Garry's Mod addon bringing VR support to TTT using VRMod.
 - HUD elements z-order incorrectly causing trippy overlap
 - C4 throws sideways from hand
 - Traitor trap hands sometimes scale incorrectly
-- Spectator warning doesn't work on the first offense
 - Held magneto stick props rarely gain huge velocity
 - Have to double click the buy menu tabs to switch between them
 - Muzzle flashes come from world model position rather than view model position

--- a/tttvr/lua/tttvr/spectator.lua
+++ b/tttvr/lua/tttvr/spectator.lua
@@ -30,7 +30,7 @@ else
 			else
 
 				-- if the player tried to enter VR while in spectator mode, send warning
-				-- vrmod_start isn't called the first time they try this unfortunately so it won't always catch it
+				-- vrmod_start isn't called the first time they try this so there is an extra one-time hook below
 				if(ply:IsSpec()) then
 					ply:ConCommand("vrmod_exit")
 					chat.AddText(Color(255, 0, 0), "YOU MUST BE ALIVE TO ENTER VR!")
@@ -43,6 +43,17 @@ else
 			timer.Simple(0, function()
 				inVR = false
 			end)
+		end
+	end)
+	
+	-- catches the first time the player tries to enter VR while in spectator mode
+	hook.Add("VRMod_Tracking","Benny:TTTVR:spectatorfirstcatchhook",function()
+		local ply = LocalPlayer()
+		if ply:Alive() then hook.Remove("VRMod_Tracking","Benny:TTTVR:spectatorfirstcatchhook") end
+		if(ply:IsSpec() and not death) then
+			ply:ConCommand("vrmod_exit")
+			chat.AddText(Color(255, 0, 0), "YOU MUST BE ALIVE TO ENTER VR!")
+			hook.Remove("VRMod_Tracking","Benny:TTTVR:spectatorfirstcatchhook")
 		end
 	end)
 	

--- a/tttvr/lua/tttvr/spectator.lua
+++ b/tttvr/lua/tttvr/spectator.lua
@@ -21,25 +21,29 @@ else
 	local inVR = false
 	local death = false
 	hook.Add("VRMod_Start","Benny:TTTVR:clientvrstarthook", function(ply)
-		inVR = true
-		if death then
-			if not (ply:IsSpec()) then
-				death = false
-			end
-		else
-			
-			-- if the player tried to enter VR while in spectator mode, send warning
-			-- vrmod_start isn't called the first time they try this unfortunately so it won't always catch it
-			if(ply:IsSpec()) then
-				ply:ConCommand("vrmod_exit")
-				chat.AddText(Color(255, 0, 0), "YOU MUST BE ALIVE TO ENTER VR!")
+		if ply == LocalPlayer() then
+			inVR = true
+			if death then
+				if not (ply:IsSpec()) then
+					death = false
+				end
+			else
+
+				-- if the player tried to enter VR while in spectator mode, send warning
+				-- vrmod_start isn't called the first time they try this unfortunately so it won't always catch it
+				if(ply:IsSpec()) then
+					ply:ConCommand("vrmod_exit")
+					chat.AddText(Color(255, 0, 0), "YOU MUST BE ALIVE TO ENTER VR!")
+				end
 			end
 		end
 	end)
-	hook.Add("VRMod_Exit","Benny:TTTVR:clientvrexithook", function()
-		timer.Simple(0, function()
-			inVR = false
-		end)
+	hook.Add("VRMod_Exit","Benny:TTTVR:clientvrexithook", function(ply)
+		if ply == LocalPlayer() then
+			timer.Simple(0, function()
+				inVR = false
+			end)
+		end
 	end)
 	
 	-- function runs on client when the player dies to force the camera to follow the ragdoll's POV 


### PR DESCRIPTION
Fix for "YOU MUST BE ALIVE TO ENTER VR!" error happening to non-vr clients when a vr player moves to spectator mode.
Apparently, the "VRMod_Start" and "VRMod_Exit" hooks get called on all clients, specifying the player actually entering/exiting vr through the first argument.